### PR TITLE
make string extension optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ Ryodo.parse("my.awesome.domain.co.jp")
 Ryodo("my.awesome.domain.co.jp")
 Ryodo["my.awesome.domain.co.jp"]
 ryodo("my.awesome.domain.co.jp")
+```
 
-# String extension
+### String extension
+
+```ruby
+require "ryodo/ext/string"
+
 "my.awesome.domain.co.jp".to_domain
 "my.awesome.domain.co.jp".ryodo
 ```
@@ -83,7 +88,7 @@ uri.host.domain
 In Gemfile:
 
 ```ruby
-gem "ryodo", :require => ["ryodo","ryodo/ext/uri"]
+gem "ryodo", :require => ["ryodo", "ryodo/ext/string", "ryodo/ext/uri"]
 ```
 
 

--- a/lib/ryodo.rb
+++ b/lib/ryodo.rb
@@ -19,7 +19,7 @@ require "ryodo/rule_set"
 require "ryodo/suffix_list"
 
 require "ryodo/methods"
-require "ryodo/ext/string"
+#require "ryodo/ext/string"
 #require "ryodo/ext/uri"
 
 # Convenient shorthands


### PR DESCRIPTION
Hi Christoph,

nice little library ;). This pull request removes the auto requiring of the string extension, I think it's better that way.

Btw, what about a method like `#domain_valid?` to simply check for correctness (instead of using tld)?

Jan
